### PR TITLE
fixup! BtHelper: Initial support for showing battery separately

### DIFF
--- a/android/bthelper/src/com/android/bluetooth/bthelper/AirPodsBatteryService.java
+++ b/android/bthelper/src/com/android/bluetooth/bthelper/AirPodsBatteryService.java
@@ -239,7 +239,6 @@ public class AirPodsBatteryService extends Service {
         }
     }
 
-    // TODO: Fix non-protected broadcast from system error spam
     private void broadcastStatusChanges(Intent intent) {
         final Intent statusIntent = new Intent("batterywidget.impl.action.update_bluetooth_data").setPackage("com.google.android.settings.intelligence");
         statusIntent.putExtra("android.bluetooth.device.action.BATTERY_LEVEL_CHANGED", intent);

--- a/android/bthelper/src/com/android/bluetooth/bthelper/models/AirPods.java
+++ b/android/bthelper/src/com/android/bluetooth/bthelper/models/AirPods.java
@@ -76,25 +76,26 @@ public class AirPods {
         final int battery = data[6];
         final int charging = data[7];
 
-        rightLeft = ((flags & FLAG_REVERSED) != 0);
+        rightLeft = ((flags & FLAG_REVERSED) == 0);
     
         if (rightLeft == false) {
             batteryLeft = (battery >> 4) & 0xf;
             batteryRight = battery & 0xf;
             chargingLeft = (charging & MASK_CHARGING_LEFT) != 0;
             chargingRight = (charging & MASK_CHARGING_RIGHT) != 0;
+            usingLeft = (flags & MASK_USING_LEFT) != 0;
+            usingRight = (flags & MASK_USING_RIGHT) != 0;
         } else {
             batteryLeft = battery & 0xf;
             batteryRight = (battery >> 4) & 0xf;
             chargingLeft = (charging & MASK_CHARGING_RIGHT) != 0;
             chargingRight = (charging & MASK_CHARGING_LEFT) != 0;
+            usingLeft = (flags & MASK_USING_RIGHT) != 0;
+            usingRight = (flags & MASK_USING_LEFT) != 0;
         }
 
         batteryCase = charging & 0xf;
         chargingCase = (charging & MASK_CHARGING_CASE) != 0;
-
-        usingLeft = (flags & MASK_USING_LEFT) != 0;
-        usingRight = (flags & MASK_USING_RIGHT) != 0;
 
         if (chargingLeft == true
             && chargingRight == true) {

--- a/android/bthelper/src/com/android/bluetooth/bthelper/models/AirPodsGen2.java
+++ b/android/bthelper/src/com/android/bluetooth/bthelper/models/AirPodsGen2.java
@@ -76,25 +76,26 @@ public class AirPodsGen2 {
         final int battery = data[6];
         final int charging = data[7];
 
-        rightLeft = ((flags & FLAG_REVERSED) != 0);
+        rightLeft = ((flags & FLAG_REVERSED) == 0);
     
         if (rightLeft == false) {
             batteryLeft = (battery >> 4) & 0xf;
             batteryRight = battery & 0xf;
             chargingLeft = (charging & MASK_CHARGING_LEFT) != 0;
             chargingRight = (charging & MASK_CHARGING_RIGHT) != 0;
+            usingLeft = (flags & MASK_USING_LEFT) != 0;
+            usingRight = (flags & MASK_USING_RIGHT) != 0;
         } else {
             batteryLeft = battery & 0xf;
             batteryRight = (battery >> 4) & 0xf;
             chargingLeft = (charging & MASK_CHARGING_RIGHT) != 0;
             chargingRight = (charging & MASK_CHARGING_LEFT) != 0;
+            usingLeft = (flags & MASK_USING_RIGHT) != 0;
+            usingRight = (flags & MASK_USING_LEFT) != 0;
         }
 
         batteryCase = charging & 0xf;
         chargingCase = (charging & MASK_CHARGING_CASE) != 0;
-
-        usingLeft = (flags & MASK_USING_LEFT) != 0;
-        usingRight = (flags & MASK_USING_RIGHT) != 0;
 
         if (chargingLeft == true
             && chargingRight == true) {

--- a/android/bthelper/src/com/android/bluetooth/bthelper/models/AirPodsGen3.java
+++ b/android/bthelper/src/com/android/bluetooth/bthelper/models/AirPodsGen3.java
@@ -76,25 +76,26 @@ public class AirPodsGen3 {
         final int battery = data[6];
         final int charging = data[7];
 
-        rightLeft = ((flags & FLAG_REVERSED) != 0);
+        rightLeft = ((flags & FLAG_REVERSED) == 0);
     
         if (rightLeft == false) {
             batteryLeft = (battery >> 4) & 0xf;
             batteryRight = battery & 0xf;
             chargingLeft = (charging & MASK_CHARGING_LEFT) != 0;
             chargingRight = (charging & MASK_CHARGING_RIGHT) != 0;
+            usingLeft = (flags & MASK_USING_LEFT) != 0;
+            usingRight = (flags & MASK_USING_RIGHT) != 0;
         } else {
             batteryLeft = battery & 0xf;
             batteryRight = (battery >> 4) & 0xf;
             chargingLeft = (charging & MASK_CHARGING_RIGHT) != 0;
             chargingRight = (charging & MASK_CHARGING_LEFT) != 0;
+            usingLeft = (flags & MASK_USING_RIGHT) != 0;
+            usingRight = (flags & MASK_USING_LEFT) != 0;
         }
 
         batteryCase = charging & 0xf;
         chargingCase = (charging & MASK_CHARGING_CASE) != 0;
-
-        usingLeft = (flags & MASK_USING_LEFT) != 0;
-        usingRight = (flags & MASK_USING_RIGHT) != 0;
 
         if (chargingLeft == true
             && chargingRight == true) {

--- a/android/bthelper/src/com/android/bluetooth/bthelper/models/AirPodsPro.java
+++ b/android/bthelper/src/com/android/bluetooth/bthelper/models/AirPodsPro.java
@@ -76,25 +76,26 @@ public class AirPodsPro {
         final int battery = data[6];
         final int charging = data[7];
 
-        rightLeft = ((flags & FLAG_REVERSED) != 0);
-    
+        rightLeft = ((flags & FLAG_REVERSED) == 0);
+
         if (rightLeft == false) {
             batteryLeft = (battery >> 4) & 0xf;
             batteryRight = battery & 0xf;
             chargingLeft = (charging & MASK_CHARGING_LEFT) != 0;
             chargingRight = (charging & MASK_CHARGING_RIGHT) != 0;
+            usingLeft = (flags & MASK_USING_LEFT) != 0;
+            usingRight = (flags & MASK_USING_RIGHT) != 0;
         } else {
             batteryLeft = battery & 0xf;
             batteryRight = (battery >> 4) & 0xf;
             chargingLeft = (charging & MASK_CHARGING_RIGHT) != 0;
             chargingRight = (charging & MASK_CHARGING_LEFT) != 0;
+            usingLeft = (flags & MASK_USING_RIGHT) != 0;
+            usingRight = (flags & MASK_USING_LEFT) != 0;
         }
 
         batteryCase = charging & 0xf;
         chargingCase = (charging & MASK_CHARGING_CASE) != 0;
-
-        usingLeft = (flags & MASK_USING_LEFT) != 0;
-        usingRight = (flags & MASK_USING_RIGHT) != 0;
 
         if (chargingLeft == true
             && chargingRight == true) {

--- a/android/bthelper/src/com/android/bluetooth/bthelper/models/AirPodsProGen2.java
+++ b/android/bthelper/src/com/android/bluetooth/bthelper/models/AirPodsProGen2.java
@@ -76,25 +76,26 @@ public class AirPodsProGen2 {
         final int battery = data[6];
         final int charging = data[7];
 
-        rightLeft = ((flags & FLAG_REVERSED) != 0);
+        rightLeft = ((flags & FLAG_REVERSED) == 0);
     
         if (rightLeft == false) {
             batteryLeft = (battery >> 4) & 0xf;
             batteryRight = battery & 0xf;
             chargingLeft = (charging & MASK_CHARGING_LEFT) != 0;
             chargingRight = (charging & MASK_CHARGING_RIGHT) != 0;
+            usingLeft = (flags & MASK_USING_LEFT) != 0;
+            usingRight = (flags & MASK_USING_RIGHT) != 0;
         } else {
             batteryLeft = battery & 0xf;
             batteryRight = (battery >> 4) & 0xf;
             chargingLeft = (charging & MASK_CHARGING_RIGHT) != 0;
             chargingRight = (charging & MASK_CHARGING_LEFT) != 0;
+            usingLeft = (flags & MASK_USING_RIGHT) != 0;
+            usingRight = (flags & MASK_USING_LEFT) != 0;
         }
 
         batteryCase = charging & 0xf;
         chargingCase = (charging & MASK_CHARGING_CASE) != 0;
-
-        usingLeft = (flags & MASK_USING_LEFT) != 0;
-        usingRight = (flags & MASK_USING_RIGHT) != 0;
 
         if (chargingLeft == true
             && chargingRight == true) {

--- a/android/bthelper/src/com/android/bluetooth/bthelper/models/Generic.java
+++ b/android/bthelper/src/com/android/bluetooth/bthelper/models/Generic.java
@@ -44,7 +44,7 @@ public class Generic {
         final int flags = data[5];
         final int battery = data[6];
 
-        rightLeft = ((flags & FLAG_REVERSED) != 0);
+        rightLeft = ((flags & FLAG_REVERSED) == 0);
 
         if (rightLeft == false) {
             batteryLeft = (battery >> 4) & 0xf;


### PR DESCRIPTION
[1] Remove TODO comment form AirPodsBatteryService
* Resetting device's data partition fix the issue

[2] Fix logic for rightLeft check
* This set to be true when value is 0 not non-0 values